### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@vercel/analytics": "^1.2.2",
-    "@vercel/kv": "^1.0.1",
     "ai": "latest",
     "cheerio": "^1.0.0-rc.12",
     "class-variance-authority": "^0.7.0",


### PR DESCRIPTION
Removed "@vercel/kv": "^1.0.1", from package.json because it is a dependency of langchain/community : ^0.0.40 and langchain: ^0.1.28. This causes a conflict because they both require @vercel/kv: ^0.0.23. Therefore there is a conflict. The package.lock should be committed as well I believe but will leave that up to the owners.